### PR TITLE
Fix/lagging proposals

### DIFF
--- a/playwright-tests/tests/proposals.spec.js
+++ b/playwright-tests/tests/proposals.spec.js
@@ -107,44 +107,17 @@ test.describe("Don't ask again enabled", () => {
         const postData = request.postDataJSON();
         if (
           transaction_completed &&
-          postData.params?.method_name === "get_proposals"
+          postData.params?.method_name === "get_all_proposal_ids"
         ) {
           const response = await route.fetch();
           const json = await response.json();
 
-          console.log("transaction completed, modifying get_proposals result");
+          console.log(
+            "transaction completed, modifying get_proposal_ids result"
+          );
           const resultObj = decodeResultJSON(json.result.result);
-          resultObj.push({
-            proposal_version: "V0",
-            id: 8,
-            author_id:
-              "8566fc4bb16e1a7446b5e9b1b8aea94b5751d5f8c658d7af18d8cdf642d7b31d",
-            social_db_post_block_height: "114956244",
-            snapshot: {
-              editor_id:
-                "8566fc4bb16e1a7446b5e9b1b8aea94b5751d5f8c658d7af18d8cdf642d7b31d",
-              timestamp: "1710767750951688236",
-              labels: [],
-              proposal_body_version: "V0",
-              name: "Test proposal ",
-              category: "Universities & Bootcamps",
-              summary: "Test proposal summary",
-              description: "the description",
-              linked_proposals: [],
-              requested_sponsorship_usd_amount: "3200",
-              requested_sponsorship_paid_in_currency: "USDC",
-              receiver_account:
-                "8566fc4bb16e1a7446b5e9b1b8aea94b5751d5f8c658d7af18d8cdf642d7b31d",
-              requested_sponsor: "neardevdao.near",
-              supervisor: "bpolania.near",
-              timeline: {
-                status: "REVIEW",
-                sponsor_requested_review: false,
-                reviewer_completed_attestation: false,
-              },
-            },
-            snapshot_history: [],
-          });
+          resultObj.push(1);
+          console.log(JSON.stringify(resultObj));
           json.result.result = encodeResultJSON(resultObj);
 
           await route.fulfill({ response, json });
@@ -191,7 +164,7 @@ test.describe("Wallet is connected", () => {
 
     const titleArea = await page.getByRole("textbox").first();
     await expect(titleArea).toBeEditable();
-    await titleArea.pressSequentially("Test proposal 123456", { delay: 10 });
+    await titleArea.pressSequentially("Test proposal 123456", { delay: 100 });
 
     await pauseIfVideoRecording(page);
 
@@ -205,7 +178,7 @@ test.describe("Wallet is connected", () => {
 
     const summary = await page.locator('textarea[type="text"]');
     await summary.pressSequentially("Test proposal summary 123456789", {
-      delay: 10,
+      delay: 100,
     });
 
     await pauseIfVideoRecording(page);
@@ -221,7 +194,7 @@ test.describe("Wallet is connected", () => {
     await page
       .locator('input[type="text"]')
       .nth(2)
-      .pressSequentially("12345", { delay: 10 });
+      .pressSequentially("12345", { delay: 100 });
     await pauseIfVideoRecording(page);
     await page.getByRole("checkbox").first().click();
     await pauseIfVideoRecording(page);

--- a/playwright-tests/tests/proposals.spec.js
+++ b/playwright-tests/tests/proposals.spec.js
@@ -162,9 +162,12 @@ test.describe("Wallet is connected", () => {
     test.setTimeout(120000);
     await page.goto("/devhub.near/widget/app?page=create-proposal");
 
+    const delay_milliseconds_between_keypress_when_typing = 300;
     const titleArea = await page.getByRole("textbox").first();
     await expect(titleArea).toBeEditable();
-    await titleArea.pressSequentially("Test proposal 123456", { delay: 200 });
+    await titleArea.pressSequentially("Test proposal 123456", {
+      delay: delay_milliseconds_between_keypress_when_typing,
+    });
 
     await pauseIfVideoRecording(page);
 
@@ -179,7 +182,7 @@ test.describe("Wallet is connected", () => {
     const summary = await page.locator('textarea[type="text"]');
     await expect(summary).toBeEditable();
     await summary.pressSequentially("Test proposal summary 123456789", {
-      delay: 200,
+      delay: delay_milliseconds_between_keypress_when_typing,
     });
 
     await pauseIfVideoRecording(page);
@@ -192,10 +195,9 @@ test.describe("Wallet is connected", () => {
 
     await pauseIfVideoRecording(page);
 
-    await page
-      .locator('input[type="text"]')
-      .nth(2)
-      .pressSequentially("12345", { delay: 200 });
+    await page.locator('input[type="text"]').nth(2).pressSequentially("12345", {
+      delay: delay_milliseconds_between_keypress_when_typing,
+    });
     await pauseIfVideoRecording(page);
     await page.getByRole("checkbox").first().click();
     await pauseIfVideoRecording(page);

--- a/playwright-tests/tests/proposals.spec.js
+++ b/playwright-tests/tests/proposals.spec.js
@@ -180,3 +180,92 @@ test.describe("Don't ask again enabled", () => {
     await pauseIfVideoRecording(page);
   });
 });
+
+test.describe("Wallet is connected", () => {
+  test.use({
+    storageState: "playwright-tests/storage-states/wallet-connected.json",
+  });
+  test("editing proposal should not be laggy", async ({ page }) => {
+    test.setTimeout(120000);
+    await page.goto("/devhub.near/widget/app?page=create-proposal");
+
+    const titleArea = await page.getByRole("textbox").first();
+    await expect(titleArea).toBeEditable();
+    await titleArea.pressSequentially("Test proposal 123456", { delay: 10 });
+
+    await pauseIfVideoRecording(page);
+
+    const categoryDropdown = await page.locator(".dropdown-toggle").first();
+    await categoryDropdown.click();
+    await page.locator(".dropdown-menu > div > div:nth-child(2) > div").click();
+
+    const disabledSubmitButton = await page.locator(
+      ".submit-draft-button.disabled"
+    );
+
+    const summary = await page.locator('textarea[type="text"]');
+    await summary.pressSequentially("Test proposal summary 123456789", {
+      delay: 10,
+    });
+
+    await pauseIfVideoRecording(page);
+
+    const descriptionArea = await page
+      .frameLocator("iframe")
+      .locator(".CodeMirror textarea");
+    await descriptionArea.focus();
+    await descriptionArea.fill(`The test proposal description.`);
+
+    await pauseIfVideoRecording(page);
+
+    await page
+      .locator('input[type="text"]')
+      .nth(2)
+      .pressSequentially("12345", { delay: 10 });
+    await pauseIfVideoRecording(page);
+    await page.getByRole("checkbox").first().click();
+    await pauseIfVideoRecording(page);
+    await expect(disabledSubmitButton).toBeAttached();
+    await page.getByRole("checkbox").nth(1).click();
+    await pauseIfVideoRecording(page);
+    await expect(disabledSubmitButton).not.toBeAttached();
+
+    const submitButton = await page.getByText("Submit Draft");
+    await submitButton.scrollIntoViewIfNeeded();
+    await submitButton.hover();
+    await pauseIfVideoRecording(page);
+    await submitButton.click();
+    const transactionText = JSON.stringify(
+      JSON.parse(await page.locator("div.modal-body code").innerText()),
+      null,
+      1
+    );
+    await expect(transactionText).toEqual(
+      JSON.stringify(
+        {
+          labels: [],
+          body: {
+            proposal_body_version: "V0",
+            name: "Test proposal 123456",
+            description: "The test proposal description.",
+            category: "DevDAO Platform",
+            summary: "Tes proposal summary 123456789",
+            linked_proposals: [],
+            requested_sponsorship_usd_amount: "12345",
+            requested_sponsorship_paid_in_currency: "USDC",
+            receiver_account: "efiz.near",
+            supervisor: null,
+            requested_sponsor: "neardevdao.near",
+            timeline: {
+              status: "DRAFT",
+            },
+          },
+        },
+        null,
+        1
+      )
+    );
+
+    await pauseIfVideoRecording(page);
+  });
+});

--- a/playwright-tests/tests/proposals.spec.js
+++ b/playwright-tests/tests/proposals.spec.js
@@ -164,7 +164,7 @@ test.describe("Wallet is connected", () => {
 
     const titleArea = await page.getByRole("textbox").first();
     await expect(titleArea).toBeEditable();
-    await titleArea.pressSequentially("Test proposal 123456", { delay: 100 });
+    await titleArea.pressSequentially("Test proposal 123456", { delay: 200 });
 
     await pauseIfVideoRecording(page);
 
@@ -177,8 +177,9 @@ test.describe("Wallet is connected", () => {
     );
 
     const summary = await page.locator('textarea[type="text"]');
+    await expect(summary).toBeEditable();
     await summary.pressSequentially("Test proposal summary 123456789", {
-      delay: 100,
+      delay: 200,
     });
 
     await pauseIfVideoRecording(page);
@@ -194,7 +195,7 @@ test.describe("Wallet is connected", () => {
     await page
       .locator('input[type="text"]')
       .nth(2)
-      .pressSequentially("12345", { delay: 100 });
+      .pressSequentially("12345", { delay: 200 });
     await pauseIfVideoRecording(page);
     await page.getByRole("checkbox").first().click();
     await pauseIfVideoRecording(page);
@@ -222,7 +223,7 @@ test.describe("Wallet is connected", () => {
             name: "Test proposal 123456",
             description: "The test proposal description.",
             category: "DevDAO Platform",
-            summary: "Tes proposal summary 123456789",
+            summary: "Test proposal summary 123456789",
             linked_proposals: [],
             requested_sponsorship_usd_amount: "12345",
             requested_sponsorship_paid_in_currency: "USDC",

--- a/src/devhub/entity/proposal/Editor.jsx
+++ b/src/devhub/entity/proposal/Editor.jsx
@@ -251,9 +251,6 @@ const [requestedSponsorshipToken, setRequestedSponsorshipToken] = useState(
 const [supervisor, setSupervisor] = useState(null);
 const [allowDraft, setAllowDraft] = useState(true);
 
-const [proposalsOptions, setProposalsOptions] = useState([]);
-//const proposalsData = Near.view("${REPL_DEVHUB_CONTRACT}", "get_proposals");
-
 const [loading, setLoading] = useState(true);
 const [disabledSubmitBtn, setDisabledSubmitBtn] = useState(false);
 const [isDraftBtnOpen, setDraftBtnOpen] = useState(false);
@@ -406,23 +403,6 @@ useEffect(() => {
     });
   }
 }, [editProposalData]);
-
-/*useEffect(() => {
-  if (
-    proposalsData !== null &&
-    Array.isArray(proposalsData) &&
-    !proposalsOptions.length
-  ) {
-    const data = [];
-    for (const prop of proposalsData) {
-      data.push({
-        label: "Id " + prop.id + " : " + prop.snapshot.name,
-        value: prop.id,
-      });
-    }
-    setProposalsOptions(data);
-  }
-}, [proposalsData]);*/
 
 const InputContainer = ({ heading, description, children }) => {
   return (

--- a/src/devhub/entity/proposal/Editor.jsx
+++ b/src/devhub/entity/proposal/Editor.jsx
@@ -250,7 +250,9 @@ const [requestedSponsorshipToken, setRequestedSponsorshipToken] = useState(
 );
 const [supervisor, setSupervisor] = useState(null);
 const [allowDraft, setAllowDraft] = useState(true);
-const proposalsData = Near.view("${REPL_DEVHUB_CONTRACT}", "get_proposals");
+
+const [proposalsOptions, setProposalsOptions] = useState([]);
+//const proposalsData = Near.view("${REPL_DEVHUB_CONTRACT}", "get_proposals");
 
 const [loading, setLoading] = useState(true);
 const [disabledSubmitBtn, setDisabledSubmitBtn] = useState(false);
@@ -259,8 +261,6 @@ const [selectedStatus, setSelectedStatus] = useState("draft");
 const [isReviewModalOpen, setReviewModal] = useState(false);
 const [amountError, setAmountError] = useState(null);
 const [isCancelModalOpen, setCancelModal] = useState(false);
-
-const [isSubmittingTransaction, setIsSubmittingTransaction] = useState(false);
 
 const [showProposalPage, setShowProposalPage] = useState(false); // when user creates/edit a proposal and confirm the txn, this is true
 const [proposalId, setProposalId] = useState(null);
@@ -352,7 +352,7 @@ useEffect(() => {
     return;
   }
   setDisabledSubmitBtn(
-    isSubmittingTransaction ||
+    isTxnCreated ||
       amountError ||
       !title ||
       !description ||
@@ -377,7 +377,7 @@ useEffect(() => {
   draftProposalData,
   consent,
   amountError,
-  isSubmittingTransaction,
+  isTxnCreated,
   showProposalPage,
 ]);
 
@@ -407,15 +407,22 @@ useEffect(() => {
   }
 }, [editProposalData]);
 
-useEffect(() => {
-  if (isSubmittingTransaction) {
-    // Trigger when proposals data change, which will happen on cache invalidation
-    setIsSubmittingTransaction(false);
-    console.log("Proposals data change, assume transaction completed");
+/*useEffect(() => {
+  if (
+    proposalsData !== null &&
+    Array.isArray(proposalsData) &&
+    !proposalsOptions.length
+  ) {
+    const data = [];
+    for (const prop of proposalsData) {
+      data.push({
+        label: "Id " + prop.id + " : " + prop.snapshot.name,
+        value: prop.id,
+      });
+    }
+    setProposalsOptions(data);
   }
-}, [proposalsData, isSubmittingTransaction]);
-
-useEffect(() => {});
+}, [proposalsData]);*/
 
 const InputContainer = ({ heading, description, children }) => {
   return (
@@ -459,7 +466,7 @@ useEffect(() => {
         proposalIds.length !== proposalIdsArray.length
       ) {
         setCreateTxn(false);
-        setProposalId(proposalIds.length - 1);
+        setProposalId(proposalIds[proposalIds.length - 1]);
         setShowProposalPage(true);
       }
     }
@@ -705,7 +712,7 @@ const SubmitBtn = () => {
             onClick={() => !disabledSubmitBtn && handleSubmit()}
             className="p-2 d-flex gap-2 align-items-center "
           >
-            {isSubmittingTransaction ? (
+            {isTxnCreated ? (
               LoadingButtonSpinner
             ) : (
               <div className={"circle " + selectedOption.iconColor}></div>
@@ -746,7 +753,6 @@ const SubmitBtn = () => {
 };
 
 const onSubmit = ({ isDraft, isCancel }) => {
-  setIsSubmittingTransaction(true);
   setCreateTxn(true);
   console.log("submitting transaction");
   const linkedProposalsIds = linkedProposals.map((item) => item.value) ?? [];


### PR DESCRIPTION
Removing the dependency to `Near.view("${REPL_DEVHUB_CONTRACT}", "get_proposals");` reduce lagging significantly. Note the new test for lagging, where you can adjust the typing speed, which is now set to a delay of 300 ms between each key press. Reducing it still shows that there is some lag, but it's quite much better than it was.